### PR TITLE
Add vagrant-vbguest as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Note: If you just need Windows Hyper-V Server 2012 R2 and do not need SQL Server
 
 - [Vagrant][]
 - [VirtualBox][]
+- [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) (install with `vagrant plugin install vagrant-vbguest`)
 
 # Install and start up
 


### PR DESCRIPTION
On a new Vagrant install, I got this error message the first time I ran `vagrant up`:

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

Vagrant:
* Unknown configuration section 'vbguest'.
```

I solved the problem by installing the vagrant-vbguest plugin.
